### PR TITLE
Revert "fix(deps): bump org.jetbrains.exposed:exposed-spring-boot-starter from 0.58.0 to 0.59.0"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -31,7 +31,7 @@ dependencies {
     developmentOnly("org.springframework.boot:spring-boot-devtools")
     runtimeOnly("org.postgresql:postgresql")
     testImplementation("org.springframework.boot:spring-boot-starter-test")
-    implementation("org.jetbrains.exposed:exposed-spring-boot-starter:0.59.0")
+    implementation("org.jetbrains.exposed:exposed-spring-boot-starter:0.58.0")
     implementation("org.jetbrains.exposed:exposed-java-time:0.59.0")
     implementation("org.flywaydb:flyway-core:11.3.1")
     ktlint("com.pinterest.ktlint:ktlint-cli:1.5.0") {


### PR DESCRIPTION
Reverts horext/app-api#216