### PR TITLE
Potential fix for code scanning alert no. 7: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -150,6 +150,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: release
     environment: ${{ inputs.environment }}
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-api/security/code-scanning/7](https://github.com/horext/app-api/security/code-scanning/7)

To fix the issue, we will add a `permissions` block to the `migrate-db` job. Since this job primarily checks out the repository and runs database migration commands, it only requires `contents: read` permissions. This change will explicitly limit the `GITHUB_TOKEN` permissions to the minimum required for the job.

The `permissions` block will be added under the `migrate-db` job definition, ensuring it applies only to this job and does not affect other jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
