### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -1,5 +1,10 @@
 name: CD Pipeline
 
+permissions:
+  contents: read
+  packages: write
+  id-token: write
+
 on:
   # Triggers the workflow on push or pull request events but only for the master branch
   workflow_call:


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-api/security/code-scanning/5](https://github.com/horext/app-api/security/code-scanning/5)

To fix the issue, we will add a `permissions` block to the workflow. This block will explicitly define the minimal permissions required for the workflow to function correctly. Based on the workflow's actions, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `packages: write` for pushing Docker images to the registry.
- `id-token: write` for authentication with the registry.

The `permissions` block will be added at the workflow level to apply to all jobs. If any job requires additional permissions, they can be defined specifically for that job.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
