### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-pr.yml
+++ b/.github/workflows/ci-pr.yml
@@ -7,6 +7,10 @@ on:
   pull_request:
     branches: [main, next, develop]
 
+# Set minimal permissions for the workflow
+permissions:
+  contents: read
+
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
   ci:


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-api/security/code-scanning/1](https://github.com/horext/app-api/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will apply to all jobs in the workflow unless overridden by job-specific `permissions`. Since the workflow uses another workflow (`ci.yml`), we will assume minimal permissions (`contents: read`) unless further details about the invoked workflow indicate additional permissions are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
