### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-main.yml
+++ b/.github/workflows/ci-cd-main.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   ci:
     name: CI
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
   cd:
     name: CD


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-api/security/code-scanning/2](https://github.com/horext/app-api/security/code-scanning/2)

To fix the issue, we will add a `permissions` block to the `ci` job. Since most basic CI workflows only require read access to the repository contents, we will set `contents: read` as the minimal permission. This change ensures that the `ci` job adheres to the principle of least privilege and does not inherit unnecessary permissions from the repository.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
