### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,10 @@ name: CI Pipeline
 
 on:
   workflow_call:   
-  
+
+permissions:
+  contents: read
+
 env:
   SPRING_DATASOURCE_DATABASE: mydb
   SPRING_DATASOURCE_HOST: localhost


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-api/security/code-scanning/4](https://github.com/horext/app-api/security/code-scanning/4)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will specify the minimal permissions required for the workflow to function. Based on the workflow's steps, it primarily interacts with the repository's contents (e.g., checking out code) and does not require write permissions. Therefore, we will set `contents: read` as the permission.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
