### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci-cd-develop.yml
+++ b/.github/workflows/ci-cd-develop.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   ci:
     name: CI
+    permissions:
+      contents: read
     uses: ./.github/workflows/ci.yml
   cd:
     name: CD


### PR DESCRIPTION
Potential fix for [https://github.com/horext/app-api/security/code-scanning/3](https://github.com/horext/app-api/security/code-scanning/3)

To fix the issue, add a `permissions` block to the `ci` job in the workflow file. Since most CI workflows only require read access to the repository contents, the minimal permissions block should specify `contents: read`. This ensures that the `ci` job adheres to the principle of least privilege and does not inherit unnecessary write permissions.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
